### PR TITLE
chore: Disable success logs if DISABLE_SUCCESS_LOG is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Playwright plugin for API schema validation against plain JSON schemas, Swagge
 
 - Environment variables:
   -  `DISABLE_SCHEMA_VALIDATION` to disable schema validation in your tests even when function `validateSchema()` is present.
+  -  `DISABLE_SUCCESS_LOG` to disable success logs in your tests.
   -  `LOG_API_UI` to enable the display of API call details in **Playwright UI** and **Trace Viewer** .
   -  `LOG_API_REPORT` to enable the display of API call details in **HTML Report** .
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,9 @@ const validateSchema = async (fixtures: object, data: any, schema: any, path?: o
         if (!errors) {
             // Schema validation passed
             await test.step(`${passResponseBodyAgainstSchema}`, async () => {
-                console.log(passResponseBodyAgainstSchema)
+                if (process.env.DISABLE_SUCCESS_LOG !== 'true') {
+                    console.log(passResponseBodyAgainstSchema)
+                }
             })
             expect(errors).toBeNull()
         } else {

--- a/tests/pwApi-custom.spec.ts
+++ b/tests/pwApi-custom.spec.ts
@@ -13,11 +13,11 @@ const issuesStyles = {
     colorPropertyMissing: '#800080'
 }
 
-test.describe('Petstore API', () => {
+test.describe('Petstore API - Playwright GET validation', () => {
 
     const baseUrl = 'https://petstore.swagger.io/v2';
 
-    test('Should validate schema of POST "/store/order" endpoint ', async ({ request, page }) => {
+    test.fail('Should validate schema of GET "/pet/findByStatus" endpoint ', async ({ request, page }) => {
 
         // GET (FAIL SCHEMA VALIDATION)
         const responseGet = await pwApi.get({ request, page }, `${baseUrl}/pet/findByStatus?status=pending`,

--- a/tests/pwApi-example.spec.ts
+++ b/tests/pwApi-example.spec.ts
@@ -6,11 +6,11 @@ import { validateSchema } from '../src/index';
 
 import petStoreSwaggerErrors from '../tests-data/schemas/petstore-swagger-errors.json';
 
-test.describe('Petstore API', () => {
+test.describe('Petstore API - Playwright POST validation', () => {
 
     const baseUrl = 'https://petstore.swagger.io/v2';
 
-    test('Should validate schema of POST "/store/order" endpoint ', async ({ request, page }) => {
+    test.fail('Should validate schema of POST "/store/order" endpoint ', async ({ request, page }) => {
 
         // POST 1 (PASS)
         const requestBody1 = {

--- a/tests/pwAxios-example.spec.ts
+++ b/tests/pwAxios-example.spec.ts
@@ -6,11 +6,11 @@ import { validateSchema } from '../src/index';
 // Swagger 2.0 Schema Document for the API under test
 import petStoreSwaggerErrors from '../tests-data/schemas/petstore-swagger-errors.json';
 
-test.describe('Petstore API', () => {
+test.describe('Petstore API - Axios GET validation', () => {
 
     const baseUrl = 'https://petstore.swagger.io/v2';
 
-    test('Should validate schema of POST "/store/order" endpoint ', async ({ request, page }) => {
+    test.fail('Should validate schema of GET "/pet/findByStatus" endpoint ', async ({ request, page }) => {
 
         const responseGet = await axiosApi.get({ page }, `${baseUrl}/pet/findByStatus?status=pending`,
             {

--- a/tests/test-plain-json-schema.spec-mock.spec.ts
+++ b/tests/test-plain-json-schema.spec-mock.spec.ts
@@ -23,13 +23,13 @@ test.describe('Suite Plain JSON Schema', async () => {
         expect(mockDataPass.length).toBe(3)
     })
 
-    test(`Test Plain JSON Schema - Mock Data Fail - Styles override`, async ({ page }) => {
+    test.fail(`Test Plain JSON Schema - Mock Data Fail - Styles override`, async ({ page }) => {
         // Fail with Styles override
         await validateSchema({ page }, mockDataFail, plainJsonSchema, undefined, issuesStyles);
         expect(mockDataPass.length).toBe(3)
     })
 
-    test(`Test Plain JSON Schema - Mock Data Pass and Fail (2 validations)`, async ({ page }) => {
+    test.fail(`Test Plain JSON Schema - Mock Data Pass and Fail (2 validations)`, async ({ page }) => {
         // Pass
         await validateSchema({ page }, mockDataPass, plainJsonSchema);
         expect(mockDataPass.length).toBe(3)


### PR DESCRIPTION
Hello and thank you for the nice plugin!

# TL;DR;

In order to avoid multiple success logs in addition to playwright CLI logs, here is a simple contribution to conditionally disable the success log when a schema is successfully validated during playwright test execution.

# PR details:


## Why?

- Improve logging clarity in CI logs and on local machine using playwright in the terminal

## What has been implemeted?

- [Disable success logs if DISABLE_SUCCESS_LOG is set](https://github.com/sclavijosuero/playwright-ajv-schema-validator/commit/bf9fe400ae54fa2ac60c783738f86968b67bcdab)
- [Document new variable introduced](https://github.com/sclavijosuero/playwright-ajv-schema-validator/commit/0783de6c1c17c716b86ad32247a4bbeb8da1e215)

**BONUS:**
- [Use test.fail for expected to fail tests](https://github.com/sclavijosuero/playwright-ajv-schema-validator/commit/2067117bbf933cf90d6c85ee15b03b698b85114e)

## Testing?

Log enabled, all success logs should be visible
```bash
npx playwright test|grep "PASSED - THE RESPONSE BODY IS VALID AGAINST THE SCHEMA"
```
Result on my machine:


![image](https://github.com/user-attachments/assets/2ad42267-4a77-4758-b704-53ed4fe6f053)

Log disabled, all success logs should not be visible anymore
```bash
DISABLE_SUCCESS_LOG=true npx playwright test|grep "PASSED - THE RESPONSE BODY IS VALID AGAINST THE SCHEMA"
```
Result on my machine:
![image](https://github.com/user-attachments/assets/b41a53a1-ddef-4521-afb0-cb75fbe68e09)
